### PR TITLE
Fix Compare2Equality

### DIFF
--- a/maps/src/main/scala/dsentric/DataEquality.scala
+++ b/maps/src/main/scala/dsentric/DataEquality.scala
@@ -12,8 +12,8 @@ sealed trait DataEquality {
 case class Compare2Equality[T](f:Int => Boolean)(implicit D:DCodec[T], O:Ordering[T]) extends DataEquality {
   def apply(x: Data, y: Data) =
     for {
-      xs <- D.unapply(x)
-      ys <- D.unapply(y)
+      xs <- D.unapply(x.value)
+      ys <- D.unapply(y.value)
     } yield f(O.compare(xs, ys))
 }
 

--- a/maps/src/test/scala/dsentricTests/DataEqualityTests.scala
+++ b/maps/src/test/scala/dsentricTests/DataEqualityTests.scala
@@ -1,0 +1,16 @@
+package dsentricTests
+
+import dsentric._
+import org.scalatest.{FunSuite, Matchers}
+import PessimisticCodecs.booleanCodec
+
+class DataEqualityTests extends FunSuite with Matchers {
+
+  test("Compare2Equality should compare boolean Data") {
+    val equality = Compare2Equality[Boolean](_ == 0)
+    val data1: Data = new DTrue
+    val data2: Data = new DTrue
+
+    equality(data1, data2) shouldBe Some(true)
+  }
+}


### PR DESCRIPTION
Looks like `unapply` in Compare2Equality was being called on the wrong thing, an easy slip to make as the method accepts `Any`. 