### PR TITLE
optimize average case performance for DArray intersects

### DIFF
--- a/maps/src/main/scala/dsentric/DObject.scala
+++ b/maps/src/main/scala/dsentric/DObject.scala
@@ -249,22 +249,15 @@ class DArray(val value:Vector[Any]) extends AnyVal with Data {
     value.nonEmpty
 
   def intersects(dArray: DArray): Boolean = {
-    val iMax = this.value.size - 1
-    val jMax = dArray.value.size - 1
-    @tailrec def _intersect(i: Int, j: Int): Boolean = {
-      if(this.value(i) == dArray.value(j))
-        true
-      else if (i == iMax && j == jMax)
-        false
-      else if (i == iMax)
-        _intersect(0, j + 1)
-      else
-        _intersect(i + 1, j)
-    }
-    if (iMax < 0 || jMax < 0)
+    if (this.value.isEmpty) false else {
+      var i = 0
+      val max = dArray.value.size
+      while(i < max) {
+        if (this.value.contains(dArray.value(i))) return true
+        i = i + 1
+      }
       false
-    else
-      _intersect(0, 0)
+    }
   }
 
   def contains(data: Data): Boolean =

--- a/maps/src/main/scala/dsentric/DObject.scala
+++ b/maps/src/main/scala/dsentric/DObject.scala
@@ -261,7 +261,10 @@ class DArray(val value:Vector[Any]) extends AnyVal with Data {
       else
         _intersect(i + 1, j)
     }
-    _intersect(0, 0)
+    if (iMax < 0 || jMax < 0)
+      false
+    else
+      _intersect(0, 0)
   }
 
   def contains(data: Data): Boolean =

--- a/maps/src/main/scala/dsentric/DObject.scala
+++ b/maps/src/main/scala/dsentric/DObject.scala
@@ -2,6 +2,7 @@ package dsentric
 
 import cats.data._
 
+import scala.annotation.tailrec
 import scala.collection.{IterableLike, mutable}
 
 trait Data extends Any {
@@ -247,8 +248,21 @@ class DArray(val value:Vector[Any]) extends AnyVal with Data {
   def nonEmpty: Boolean =
     value.nonEmpty
 
-  def intersects(dArray: DArray): Boolean =
-    intersect(dArray).nonEmpty
+  def intersects(dArray: DArray): Boolean = {
+    val iMax = this.value.size - 1
+    val jMax = dArray.value.size - 1
+    @tailrec def _intersect(i: Int, j: Int): Boolean = {
+      if(this.value(i) == dArray.value(j))
+        true
+      else if (i == iMax && j == jMax)
+        false
+      else if (i == iMax)
+        _intersect(0, j + 1)
+      else
+        _intersect(i + 1, j)
+    }
+    _intersect(0, 0)
+  }
 
   def contains(data: Data): Boolean =
     value.contains(data.value)

--- a/maps/src/test/scala/dsentricTests/DArrayTests.scala
+++ b/maps/src/test/scala/dsentricTests/DArrayTests.scala
@@ -1,0 +1,28 @@
+package dsentricTests
+
+import dsentric._
+import org.scalatest.{FunSuite, Matchers}
+
+class DArrayTests extends FunSuite with Matchers {
+  import PessimisticCodecs._
+  implicit def strictness: Strictness = MaybePessimistic
+
+  test("Intersects is false for empty DArrays") {
+    val d1 = DArray(Vector[Any]():_*)
+    val d2 = DArray(Vector[Any]():_*)
+
+    d1.intersects(d2) shouldBe false
+  }
+  test("Intersects is false for disjunct non-empty DArrays") {
+    val d1 = DArray(Vector[Any](1,2,3,4):_*)
+    val d2 = DArray(Vector[Any](5,6,7,8):_*)
+
+    d1.intersects(d2) shouldBe false
+  }
+  test("Intersects is true for DArrays with a common element") {
+    val d1 = DArray(Vector[Any](1,2,3,4):_*)
+    val d2 = DArray(Vector[Any](5,6,7,4):_*)
+
+    d1.intersects(d2) shouldBe true
+  }
+}


### PR DESCRIPTION
Microbenchmarks show that average case performance is improved by 2x vs the naïve implementation which computes the entire intersection instead of terminating when a common element is found.